### PR TITLE
test against 0.4 and 0.5 separately on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly


### PR DESCRIPTION
`release` will change to 0.5 soon, so add 0.4 explicitly to continue testing there
0.5 means the latest rc now, will mean the latest release once final is out
