### PR TITLE
[WIP] Index comparison

### DIFF
--- a/src/Einsum.jl
+++ b/src/Einsum.jl
@@ -242,6 +242,8 @@ function get_indices!(
                 end
             end
         end
+    elseif ex.head == :comparison
+        # pass as is to allow expressions like `@einsum B[i, j] := (i == j) * A[i, j]`
     else
         # e.g. 2*A[i,j] or transpose(A[i,j])
         @assert ex.head == :call

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -274,3 +274,10 @@ let
   @test isapprox(A1,A3)
   @test isapprox(A2,A3)
 end
+
+# Test index comparison
+let
+    A = rand(10, 10)
+    @einsum B[i,j] := (i == j) * A[i,j]
+    @test B == A .* eye(size(A, 1))
+end


### PR DESCRIPTION
During work on tensor differentiation, I've found that derivative `dC/dA` of matrix multiplication `C = A * B` may be expressed as:

```
dCdA[i, j, m, n] = (i == m) * B[n, j]
```

That is, derivative is a rank-4 tensor with elements on diagonal `i == m` set to `B[n, j]` and all other elements set to 0. This PR allows such expressions in Einsum.jl. 

There's currently an issue with `:=` operator, but before going further I'd like to hear your opinion about this feature. Note that this sounds like the most optimal solution to me, but I also considered: 
1. Wrapping expression in a function like `zero_if_not(B[n, j], i, m)` which does the same, but doesn't require modifications in Einsum.jl.
2. Using more general conditions, maybe with a different macro like `@einsumcond`. 

So the solution in this PR might not be optimal and I'm open to critiques and suggestions. 
