### PR TITLE
generating auxiliary variable names instead of using hard coded ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
 julia:
   - 0.5
+  - 0.6
   - nightly


### PR DESCRIPTION
It's a pity we can't use `s` or `T` inside `@einsum`'ed expressions just because these variables are used in generated code. In particular, in Espresso.jl I've got a (generated, not hand-crafted) code similar to:

```
@einsum y[i] := x[i, s]
``` 
which failed  with:

> ERROR: syntax: local "s" declared twice

I didn't know what is the  best way to fix it, so just replaced `s` and `T` with generated symbols. 