### PR TITLE
Return value of assigned array

### DIFF
--- a/src/Einsum.jl
+++ b/src/Einsum.jl
@@ -167,6 +167,7 @@ function _einsum(ex::Expr, inbound=true, simd=false)
                     $ex_get_type
                     $ex
                 end
+                $(esc(lhs_arr[1]))
             end
         end
     else
@@ -177,6 +178,7 @@ function _einsum(ex::Expr, inbound=true, simd=false)
                 $ex_get_type
                 $ex
             end
+            $(esc(lhs_arr[1]))
         end
     end
 end


### PR DESCRIPTION
Adds the name of the lhs array to the end of the returned expression. I think that's all which is needed to "fix" #22?