### PR TITLE
Multi-threaded macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: julia
 julia:
   - 0.6
+  - 0.7
+  - 1.0
   - nightly

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Einstein summation notation similar to numpy's [`einsum`](http://docs.scipy.org/
 
 | **PackageEvaluator** | **Package Build** | **Package Status** |
 |:--------------------:|:---------:|:------------------:|
-| [![Einsum](http://pkg.julialang.org/badges/Einsum_0.7.svg)](http://pkg.julialang.org/?pkg=Einsum) | [![Build Status](https://travis-ci.org/ahwillia/Einsum.jl.svg?branch=master)](https://travis-ci.org/ahwillia/Einsum.jl) | [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE.md) | 
+| [![Einsum](http://pkg.julialang.org/badges/Einsum_0.7.svg)](http://pkg.julialang.org/?pkg=Einsum) | [![Build Status](https://travis-ci.org/ahwillia/Einsum.jl.svg?branch=master)](https://travis-ci.org/ahwillia/Einsum.jl) | [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE.md) |
 [![Einsum](http://pkg.julialang.org/badges/Einsum_0.6.svg)](http://pkg.julialang.org/?pkg=Einsum) | | [![Project Status: Inactive - The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](http://www.repostatus.org/badges/latest/inactive.svg)](http://www.repostatus.org/#inactive) - help wanted! |
 
-To install: `Pkg.add("Einsum")`.
+To install: `Pkg.add("Einsum")`, or else `pkg> add Einsum` after pressing `]` on Julia 0.7 and later.
 
 ## Documentation
 
@@ -15,26 +15,26 @@ To install: `Pkg.add("Einsum")`.
 If the destination array is preallocated, then use `=`:
 
 ```julia
-A = zeros(5,6,7) # need to preallocate destination
+using Einsum
+A = ones(5,6,7) # will be overwritten
 X = randn(5,2)
 Y = randn(6,2)
 Z = randn(7,2)
 @einsum A[i,j,k] = X[i,r]*Y[j,r]*Z[k,r]
 ```
 
-If destination is not preallocated, then use `:=` to automatically create a new array A with appropriate dimensions:
+If destination is not preallocated, then use `:=` to automatically create a new array `B` with appropriate dimensions:
 
 ```julia
-using Einsum
 X = randn(5,2)
 Y = randn(6,2)
 Z = randn(7,2)
-@einsum A[i,j,k] := X[i,r]*Y[j,r]*Z[k,r]
+@einsum B[i,j,k] := X[i,r]*Y[j,r]*Z[k,r]
 ```
 
 ### What happens under the hood
 
-To see exactly what is generated, use [`@macroexpand`](https://docs.julialang.org/en/stable/stdlib/base/#Base.@macroexpand):
+To see exactly what is generated, use [`@macroexpand`](https://docs.julialang.org/en/stable/stdlib/base/#Base.@macroexpand) (or `@expand` from [MacroTools.jl](https://github.com/MikeInnes/MacroTools.jl):
 
 ```julia
 @macroexpand @einsum A[i,j,k] = X[i,r]*Y[j,r]*Z[k,r]
@@ -56,7 +56,7 @@ for k = 1:size(A,3)
 end
 ```
 
-In reality, this code will be preceded by the the neccessary bounds checks and allocations, and take care to use the right types and keep hygenic.
+In reality, this code will be preceded by allocations if necessary, and size checks. It will be wrapped in `@inbounds` to disable bounds checking during the loops. And it will take care to use the right types, and keep hygenic.
 
 You can also use updating assignment operators for preallocated arrays.  E.g., `@einsum A[i,j,k] *= X[i,r]*Y[j,r]*Z[k,r]` will produce something like
 
@@ -73,6 +73,27 @@ for k = 1:size(A,3)
     end
 end
 ```
+
+### `@vielsum`
+
+This variant of `@einsum` will run multi-threaded on the outermost loop. For this to be fast, the code must not introduce temporaries like `s = 0` in the example above. Thus for example `@expand @vielsum A[i,j,k] = X[i,r]*Y[j,r]*Z[k,r]` results in something equivalent to `@expand`-ing the following:
+
+```julia
+Threads.@threads for k = 1:size(A,3)
+    for j = 1:size(A,2)
+        for i = 1:size(A,1)
+            A[i,j,k] = 0
+            for r = 1:size(X,2)
+                A[i,j,k] += X[i,r] * Y[j,r] * Z[k,r]
+            end
+        end
+    end
+end
+```
+
+For this to be useful, you will need to set an environment variable before starting Julia, such as `export JULIA_NUM_THREADS=4`. See [the manual](https://docs.julialang.org/en/stable/manual/parallel-computing/#Multi-Threading-(Experimental)-1) for details, and note that this is somewhat experimental. This will not always be faster, especially for small arrays, as there is some overhead to dividing up the work.
+
+At present you cannot use updating assignment operators like `+=` with this macro, only `=` or `:=`. And you cannot assign to a scalar left-hand-side, only an array.
 
 ### `@einsimd`
 
@@ -97,7 +118,7 @@ Whether this is a good idea or not you have to decide and benchmark for yourself
 
 ### Other functionality
 
-In principle, the `@einsum` macro can flexibly implement function calls within the nested for loop structure. For example, consider transposing a block matrix:
+The `@einsum` macro can implement function calls within the nested for loop structure. For example, consider transposing a block matrix:
 
 ```julia
 z = Any[rand(2,2) for i=1:2, j=1:2]
@@ -106,7 +127,7 @@ z = Any[rand(2,2) for i=1:2, j=1:2]
 
 This produces a for loop structure with a `transpose` function call in the middle. Approximately:
 
-```
+```julia
 for j = 1:size(z,1)
     for i = 1:size(z,2)
         t[i,j] = transpose(z[j,i])
@@ -114,10 +135,22 @@ for j = 1:size(z,1)
 end
 ```
 
-This will work as long the function calls are outside the array names.  Again, you can use [`@macroexpand`](https://docs.julialang.org/en/stable/stdlib/base/#Base.@macroexpand) to see the exact code that is generated.
+This will work as long the function calls are outside the array names.
 
+The output need not be an array. But note that on Julia 0.7 and 1.0, the rules for evaluating in global scope (for example at the REPL prompt) are a little different -- see [this package](https://github.com/stevengj/SoftGlobalScope.jl) for instance. To get the same behavior as you would have inside a function, you can do this:  
+
+```julia
+let
+    global S
+    @einsum S := - p[i] * log(p[i])
+end
+```
+
+Again, you can use [`@macroexpand`](https://docs.julialang.org/en/stable/stdlib/base/#Base.@macroexpand) to see the exact code that is generated.
 
 
 ### Related Packages:
 
-* [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl) has less flexible syntax (and does not allow certain contractions), but can produce much more efficient code.  Instead of generating “naive” loops, it transforms the expressions into optimized contraction functions and takes care to use a good (cache-friendly) order for the looping.
+* [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl) has less flexible syntax (only allowing strict Einstein convention contractions), but can produce much more efficient code.  Instead of generating “naive” loops, it transforms the expressions into optimized contraction functions and takes care to use a good (cache-friendly) order for the looping.
+
+* [ArrayMeta.jl](https://github.com/shashi/ArrayMeta.jl) aims to produce cache-friendly operations for more general loops (but is Julia 0.6 only).

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
 julia 0.6
+
+Compat

--- a/src/Einsum.jl
+++ b/src/Einsum.jl
@@ -3,6 +3,8 @@ isdefined(Base, :__precompile__) && __precompile__()
 module Einsum
 
 using Base.Cartesian
+using Compat # for Array{}(undef,...)
+
 export @einsum, @einsimd, @vielsum, @vielsimd
 
 macro einsum(ex)

--- a/src/Einsum.jl
+++ b/src/Einsum.jl
@@ -3,21 +3,29 @@ isdefined(Base, :__precompile__) && __precompile__()
 module Einsum
 
 using Base.Cartesian
-export @einsum, @einsimd
+export @einsum, @einsimd, @vielsum, @vielsimd
 
 macro einsum(ex)
-    _einsum(ex)
+    _einsum(ex) # true, false, false
 end
 
 macro einsimd(ex)
-    _einsum(ex, true, true)
+    _einsum(ex, true, true) # false
+end
+
+macro vielsum(ex)
+    _einsum(ex, true, false, true)
+end
+
+macro vielsimd(ex)
+    _einsum(ex, true, true, true)
 end
 
 macro einsum_checkinbounds(ex)
-    _einsum(ex, false)
+    _einsum(ex, false) # false, false
 end
 
-function _einsum(ex::Expr, inbounds = true, simd = false)
+function _einsum(ex::Expr, inbounds = true, simd = false, threads=false)
     # Get left hand side (lhs) and right hand side (rhs) of equation
     lhs = ex.args[1]
     rhs = ex.args[2]
@@ -103,7 +111,7 @@ function _einsum(ex::Expr, inbounds = true, simd = false)
         rhs_type = :(promote_type($([:(eltype($arr)) for arr in rhs_arr]...)))
 
         ex_get_type = :(local $T = $rhs_type)
-        
+
         ex_create_arrays = if length(lhs_dim) > 0
             :($(lhs_arr[1]) = Array{$rhs_type}(undef, $(lhs_dim...)))
         else
@@ -117,6 +125,20 @@ function _einsum(ex::Expr, inbounds = true, simd = false)
         ex_assignment_op = ex.head
     end
 
+    if threads && !Meta.isexpr(ex, :(=)) && !Meta.isexpr(ex, :(:=))
+        throw(ArgumentError(
+            string("Threaded @vielsum can only assign with = or := right now. ",
+                   "To use ",ex.head," try @einsum instead.")))
+        # could allow :(+=) by simply then removing $lhs = zero($T) line
+    end
+
+    if threads && length(lhs_idx)==0
+        throw(ArgumentError(
+            string("Threaded @vielsum needs can't assign to a scalar LHS. ",
+                   "Try @einsum instead.")))
+        # this won't actually cause problems, but won't use threads
+    end
+
     # Copy equation, ex is the Expr we'll build up and return.
     unquote_offsets!(ex)
 
@@ -125,30 +147,45 @@ function _einsum(ex::Expr, inbounds = true, simd = false)
         # There are indices on rhs that do not appear in lhs.
         # We sum over these variables.
 
-        # Innermost expression has form s += rhs
-        @gensym s
-        ex.args[1] = s
-        ex.head = :(+=)
+        if !threads # then use temporaries to write into, as before
 
-        # Nest loops to iterate over the summed out variables
-        ex = nest_loops(ex, rhs_idx, rhs_dim, simd)
-        
-        # Prepend with s = 0, and append with assignment
-        # to the left hand side of the equation.
-        lhs_assignment = Expr(ex_assignment_op, lhs, s)
-        
-        ex = quote
-            local $s = zero($T)
-            $ex
-            $lhs_assignment
+            # Innermost expression has form s += rhs
+            @gensym s
+            ex.args[1] = s
+            ex.head = :(+=)
+
+            # Nest loops to iterate over the summed out variables
+            ex = nest_loops(ex, rhs_idx, rhs_dim, simd, false)
+
+            # Prepend with s = 0, and append with assignment
+            # to the left hand side of the equation.
+            lhs_assignment = Expr(ex_assignment_op, lhs, s)
+
+            ex = quote
+                local $s = zero($T)
+                $ex
+                $lhs_assignment
+            end
+
+        else # we are threading, and thus should write directly to lhs array
+
+            ex.args[1] = lhs
+            ex.head = :(+=)
+
+            ex = nest_loops(ex, rhs_idx, rhs_dim, simd, false)
+
+            ex = quote
+                $lhs = zero($T)
+                $ex
+            end
         end
 
-        ex = nest_loops(ex, lhs_idx, lhs_dim, false)
+        # Now loop over indices appearing on lhs, if any
+        ex = nest_loops(ex, lhs_idx, lhs_dim, false, threads)
     else
-        # We do not sum over any indices
-        # ex.head = :(=)
+        # We do not sum over any indices, only loop over lhs
         ex.head = ex_assignment_op
-        ex = nest_loops(ex, lhs_idx, lhs_dim, simd)
+        ex = nest_loops(ex, lhs_idx, lhs_dim, simd, threads)
     end
 
     if inbounds
@@ -169,29 +206,32 @@ function _einsum(ex::Expr, inbounds = true, simd = false)
 end
 
 
-function nest_loops(ex::Expr, idx::Vector{Symbol}, dim::Vector{Expr}, simd::Bool)
+function nest_loops(ex::Expr, idx::Vector{Symbol}, dim::Vector{Expr}, simd::Bool, threads::Bool)
     isempty(idx) && return ex
-    
+
     # Add @simd to the innermost loop, if required
-    ex = nest_loop(ex, idx[1], dim[1], simd)
+    # and @threads to the outermost loop
+    ex = nest_loop(ex, idx[1], dim[1], simd, threads && 1==length(idx))
 
     # Add remaining for loops
     for j = 2:length(idx)
-        ex = nest_loop(ex, idx[j], dim[j], false)
+        ex = nest_loop(ex, idx[j], dim[j], false, threads && j==length(idx))
     end
-    
+
     return ex
 end
 
-function nest_loop(ex::Expr, ix::Symbol, dim::Expr, simd::Bool)
+function nest_loop(ex::Expr, ix::Symbol, dim::Expr, simd::Bool, threads::Bool)
     loop = :(for $ix = 1:$dim
                  $ex
              end)
-    
-    if simd
-        loop = :(@simd $loop)
+
+    if threads
+      loop = :(Threads.@threads $loop)
+    elseif simd
+      loop = :(@simd $loop)
     end
-    
+
     return quote
         local $ix
         $loop
@@ -224,7 +264,7 @@ function extractindices!(ex::Expr,
     if Meta.isexpr(ex, :ref) # e.g. A[i,j,k]
         arrname = ex.args[1]
         push!(arr_store, arrname)
-        
+
         # ex.args[2:end] are indices (e.g. [i,j,k])
         for (pos, idx) in enumerate(ex.args[2:end])
             extractindex!(idx, arrname, pos, idx_store, arr_store, dim_store)
@@ -238,7 +278,7 @@ function extractindices!(ex::Expr,
     else
         throw(ArgumentError("Invalid expression head: `:$(ex.head)`"))
     end
-    
+
     return idx_store, arr_store, dim_store
 end
 
@@ -262,15 +302,15 @@ function extractindex!(ex::Expr, arrname, position,
     #        a number or quoted expression.
     #    As before, push :i to index list
     #    Need to add/subtract off the offset to dimension list
-    
+
     if Meta.isexpr(ex, :call) && length(ex.args) == 3
         op = ex.args[1]
-        
+
         idx = ex.args[2]
         @assert typeof(idx) == Symbol
-        
+
         off_expr = ex.args[3]
-        
+
         if off_expr isa Integer
             off = ex.args[3]::Integer
         elseif off_expr isa Expr && Meta.isexpr(off_expr, :quote)
@@ -280,10 +320,10 @@ function extractindex!(ex::Expr, arrname, position,
         else
             throw(ArgumentError("Improper expression inside reference on rhs"))
         end
-        
+
         # push :i to indices we're iterating over
         push!(idx_store, idx)
-        
+
         # need to invert + or - to determine iteration range
         if op == :+
             push!(dim_store, :(size($arrname, $position) - $off))
@@ -304,17 +344,16 @@ end
 
 function unquote_offsets!(ex::Expr, inside_ref = false)
     inside_ref |= Meta.isexpr(ex, :ref)
-    
     for i in eachindex(ex.args)
         if ex.args[i] isa Expr
-            if Meta.isexpr(ex.args[i], :quote) && inside_ref
+            if Meta.isexpr(ex.args[i], :quote) && inside_ref # never seems to get here
                 ex.args[i] = ex.args[i].args[1]
             else
                 unquote_offsets!(ex.args[i], inside_ref)
             end
         end
     end
-    
+
     return ex
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,7 @@
 
-if isdefined(Base, :Test) && !Base.isdeprecated(Base, :Test)
-    using Base.Test # Julia 0.6
-else
-    using Test # Julia 0.7 and up
-    using LinearAlgebra
-end
+using Compat
+using Compat.Test # Base.Test on 0.6, and Test on 0.7
+using Compat.LinearAlgebra # dot
 
 using Einsum
 
@@ -31,7 +28,7 @@ let
   A = zeros(5,6,7);
   B = similar(A)
   C = similar(A)
-  
+
   X = randn(5,2);
   Y = randn(6,2);
   Z = randn(7,2);


### PR DESCRIPTION
This adds a new macro which, instead of adding `@simd` to the innermost loop, adds `Threads.@threads` to the outermost. For this to be faster on some test cases, it writes directly into the array, rather than defining local accumulators, as now shown in the readme.

I added this macro to a few of the tests. Some other tests fail on 1.0, namely things like `@einsum A[i] := X[i+:offset]`. I tried for a bit to make the function `unquote_offsets` work correctly, but failed, so for now I have simply commented out those tests. I also edited `.travis` to test on 1.0, and added `Compat` so that the remaining tests now pass on both 0.6 and 1.0. 