### PR TITLE
Make it a Pkg3 project

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,11 @@
+name = "Einsum"
+uuid = "18756830-0e95-11e9-2f88-63828ca5be2a"
+license = "MIT"
+authors = ["Alex Williams <alex.h.willia@gmail.com>", "Philipp Gabler <phipsgabler@users.noreply.github.com>"]
+version = "0.3.0"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+
+[compat]
+julia = "0.6, 0.7, 1.0"


### PR DESCRIPTION
I tend to use the new Pkg3 projects for all the stuff I write, and it's getting the new standard anyway. So here's a `Project.toml` for Einsum.

A couple of questions:

- As far as I understand, commiting `Manifest.toml` is optional, and only necessary if one wants to track the exact state of dependencies -- so I left it out for now.
- Is the `authors` field supposed to contain all contributors? 
- Anything else to critique? I "hardcoded" the three versions we support, anything wrong with that?