### PR TITLE
Fix UUID for registration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "Einsum"
-uuid = ""b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
+uuid = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
 license = "MIT"
 authors = ["Alex Williams <alex.h.willia@gmail.com>", "Philipp Gabler <phipsgabler@users.noreply.github.com>"]
 version = "0.4.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,11 @@
 name = "Einsum"
-uuid = "18756830-0e95-11e9-2f88-63828ca5be2a"
+uuid = ""b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
 license = "MIT"
 authors = ["Alex Williams <alex.h.willia@gmail.com>", "Philipp Gabler <phipsgabler@users.noreply.github.com>"]
-version = "0.3.0"
+version = "0.4.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
-julia = "0.6, 0.7, 1.0"
+julia = "0.6, 0.7, 1.0, 1.1"


### PR DESCRIPTION
Re #33, the CI error message from https://github.com/JuliaLang/METADATA.jl/pull/21042  looks like this:
```
ERROR: LoadError: LoadError: Tagged version 0.4.0 of Einsum declares the package UUID to be "18756830-0e95-11e9-2f88-63828ca5be2a" in its Project file, which does not match the package's METADATA-compatible UUID "b7d42ee7-0b51-5a75-98ca-779d3107e4c0".
To fix this error, change the UUID to be "b7d42ee7-0b51-5a75-98ca-779d3107e4c0" and retag.
```