### PR TITLE
Drop 0.6 & fix #37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: julia
+
+os:
+  - linux
+  - osx
+
 julia:
   - 1.0
   - 1.1
+  - 1.2
   - nightly
+
+matrix:
+  allow_failures:
+  - julia: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 julia:
-  - 0.6
   - 0.7
   - 1.0
   - 1.1

--- a/Project.toml
+++ b/Project.toml
@@ -17,4 +17,4 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "LinearAlgebra"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ version = "0.5.0"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
-julia = "0.7, 1.0, 1.1"
+julia = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,6 @@ authors = ["Alex Williams <alex.h.willia@gmail.com>",
            "Philipp Gabler <phipsgabler@users.noreply.github.com>"]
 version = "0.5.0"
 
-[deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-
 [compat]
 julia = "1.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,10 @@ license = "MIT"
 authors = ["Alex Williams <alex.h.willia@gmail.com>", 
            "Michael Abbott <mcabbott@users.noreply.github.com>",
            "Philipp Gabler <phipsgabler@users.noreply.github.com>"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
-julia = "0.6, 0.7, 1.0, 1.1"
+julia = "0.7, 1.0, 1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -11,3 +11,10 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
 julia = "1.0"
+
+[extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 | **Package Build** | **Package Status** |
 |:---------:|:------------------:|
 | [![Build Status](https://travis-ci.org/ahwillia/Einsum.jl.svg?branch=master)](https://travis-ci.org/ahwillia/Einsum.jl) | [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE.md) |
-[![Einsum](http://pkg.julialang.org/badges/Einsum_0.6.svg)](http://pkg.julialang.org/?pkg=Einsum) | [![Project Status: Inactive - The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](http://www.repostatus.org/badges/latest/inactive.svg)](http://www.repostatus.org/#inactive) - help wanted! |
+[![Documentation](https://camo.githubusercontent.com/f7b92a177c912c1cc007fc9b40f17ff3ee3bb414/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f646f63732d737461626c652d626c75652e737667)](https://pkg.julialang.org/docs/Einsum/ifPEh/0.4.1/) | [![Project Status: Inactive - The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](http://www.repostatus.org/badges/latest/inactive.svg)](http://www.repostatus.org/#inactive) - help wanted! |
 
 
 This package exports a single macro `@einsum`, which implements *similar* notation to the [Einstein
 summation convention](https://en.wikipedia.org/wiki/Einstein_notation) to flexibly specify
-operations on Julia `Array`s, similar to numpy's
-[`einsum`](http://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.einsum.html) function
-(but more flexible!).
+operations on Julia `Array`s. This is similar to numpy's
+[`einsum`](http://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.einsum.html) function,
+but more flexible!
 
-For example, basic matrix multiplication can be implemented as:
+For example, basic matrix multiplication can be implemented as follows, with an implicit sum over `k`:
 
 ```julia
 @einsum A[i, j] := B[i, k] * C[k, j]
@@ -36,13 +36,9 @@ Z = randn(7, 2)
 @einsum A[i, j, k] = X[i, r] * Y[j, r] * Z[k, r]
 ```
 
-If destination is not preallocated, then use `:=` to automatically create a new array for the result:
+If destination is not preallocated, then use `:=`:
 
 ```julia
-X = randn(5, 2)
-Y = randn(6, 2)
-Z = randn(7, 2)
-
 # Create new array B with appropriate dimensions:
 @einsum B[i, j, k] := X[i, r] * Y[j, r] * Z[k, r]
 ```
@@ -217,27 +213,25 @@ end
 
 This will work as long the function calls are outside the array names. Again, you can use [`@macroexpand`](https://docs.julialang.org/en/stable/stdlib/base/#Base.@macroexpand) to see the exact code that is generated.
 
-The output need not be an array. But note that on Julia 0.7 and 1.0, the rules for evaluating in global scope (for example at the REPL prompt) are a little different -- see [this package](https://github.com/stevengj/SoftGlobalScope.jl) for instance (which is loaded in [IJulia](https://github.com/JuliaLang/IJulia.jl) notebooks). To get the same behavior as you would have inside a function, you use a `let` block:  
+The `@einsum` macro can sum over all indices, to produce a scalar, for example:
 
 ```julia
 p = rand(5); p .= p ./ sum(p)
-let
-    global S
-    @einsum S := - p[i] * log(p[i])
-end
+
+@einsum S := - p[i] * log(p[i])
 ```
 
-Or perhaps clearer, explicitly define a function:
+Note that writing `@einsum S[] := - p[i] * log(p[i])` to produce a zero-dimensional array is 
+presently not supported. 
 
-```julia
-m(pq, p, q) = @einsum I := pq[i,j] * log(pq[i,j] / p[i] / q[j])
-
-m(rand(5,10), rand(5), rand(10))
-```
-
-
-### Related Packages:
+## Related Packages
 
 * [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl) has less flexible syntax (only allowing strict Einstein convention contractions), but can produce much more efficient code.  Instead of generating “naive” loops, it transforms the expressions into optimized contraction functions and takes care to use a good (cache-friendly) order for the looping.
 
-* [ArrayMeta.jl](https://github.com/shashi/ArrayMeta.jl) aims to produce cache-friendly operations for more general loops (but is Julia 0.6 only).
+* [TensorCast.jl](https://github.com/mcabbott/TensorCast.jl) uses a similar similar index notation
+to express broadcasting expressions, as well as sums, products and other reductions of these.
+
+* [ArrayMeta.jl](https://github.com/shashi/ArrayMeta.jl) aims to produce cache-friendly operations for more general loops, but only supports Julia 0.6.
+
+* [OMEinsum.jl](https://nuget.pkg.github.com/under-Peter/OMEinsum.jl) is work in progress on a 
+Google Summer of Code project, to produce efficient differentiable tensor networks.

--- a/README.md
+++ b/README.md
@@ -233,5 +233,5 @@ to express broadcasting expressions, as well as sums, products and other reducti
 
 * [ArrayMeta.jl](https://github.com/shashi/ArrayMeta.jl) aims to produce cache-friendly operations for more general loops, but only supports Julia 0.6.
 
-* [OMEinsum.jl](https://nuget.pkg.github.com/under-Peter/OMEinsum.jl) is work in progress on a 
+* [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl) is work in progress on a 
 Google Summer of Code project, to produce efficient differentiable tensor networks.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.6
-
-Compat

--- a/src/Einsum.jl
+++ b/src/Einsum.jl
@@ -1,12 +1,6 @@
-isdefined(Base, :__precompile__) && __precompile__()
-
 module Einsum
 
-
-using Compat # for Array{}(undef,...)
-
 export @einsum, @einsimd, @vielsum, @vielsimd
-
 
 macro einsum(ex)
     _einsum(ex) # true, false, false
@@ -42,7 +36,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
 
     # Get info on the right-hand side
     rhs_arrays, rhs_indices, rhs_axis_exprs = extractindices(rhs)
-    
+
     check_index_occurrence(lhs_indices, rhs_indices)
 
     # remove duplicate indices on left-hand and right-hand side
@@ -54,7 +48,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
     for i in reverse(eachindex(rhs_indices))
         duplicated = false
         di = rhs_axis_exprs[i]
-        
+
         for j = 1:(i - 1)
             if rhs_indices[j] == rhs_indices[i]
                 # found a duplicate
@@ -65,7 +59,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
                 push!(dimension_checks, :(@assert $dj == $di))
             end
         end
-        
+
         for j = eachindex(lhs_indices)
             if lhs_indices[j] == rhs_indices[i]
                 dj = lhs_axis_exprs[j]
@@ -80,7 +74,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
                 duplicated = true
             end
         end
-        
+
         if duplicated
             deleteat!(rhs_indices, i)
             deleteat!(rhs_axis_exprs, i)
@@ -104,7 +98,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
                 push!(dimension_checks, :(@assert $dj == $di))
             end
         end
-        
+
         if duplicated
             deleteat!(lhs_indices, i)
             deleteat!(lhs_axis_exprs, i)
@@ -149,7 +143,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
             "Try @einsum instead.")))
     end
 
-    
+
     # copy the index expression to modify it; loop_expr is the Expr we'll build loops around
     loop_expr = unquote_offsets!(copy(expr))
 
@@ -207,12 +201,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
         $type_definition
         $output_definition
         $(dimension_checks...)
-        
-        # remove let when we drop 0.6 support -- see #31
-        let $([lhs_indices; rhs_indices]...)
-            $loop_expr
-        end
-
+        $loop_expr
         $(lhs_arrays[1])
     end
 
@@ -291,8 +280,8 @@ end
 """
     extractindices(expr) -> (array_names, index_names, axis_expressions)
 
-Compute all `index_names` and respective axis calculations of an expression 
-involving the arrays with `array_names`. Everything is ordered by first 
+Compute all `index_names` and respective axis calculations of an expression
+involving the arrays with `array_names`. Everything is ordered by first
 occurence in `expr`.
 
 # Examples
@@ -406,7 +395,7 @@ end
 
 function unquote_offsets!(expr::Expr, inside_ref = false)
     inside_ref |= Meta.isexpr(expr, :ref)
-    
+
     for i in eachindex(expr.args)
         if expr.args[i] isa Expr
             if Meta.isexpr(expr.args[i], :quote) && inside_ref # never seems to get here

--- a/src/Einsum.jl
+++ b/src/Einsum.jl
@@ -116,7 +116,7 @@ function _einsum(expr::Expr, inbounds = true, simd = false, threads = false)
 
         type_definition = :(local $T = $rhs_type)
 
-        output_definition = if length(lhs_axis_exprs) > 0
+        output_definition = if !(lhs isa Symbol)
             :($(lhs_arrays[1]) = Array{$T}(undef, $(lhs_axis_exprs...)))
         else
             :($(lhs_arrays[1]) = zero($T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,3 +287,15 @@ end
     @test isapprox(A1, A3)
     @test isapprox(A2, A3)
 end
+
+@testset "Scalar output, issue #37" begin
+
+    a = [1 0; 0 1]
+    @einsum b := a[i,i]
+    @einsum c[] := a[i,i]
+
+    @test b == c[] == 2
+    @test b isa Int
+    @test c isa Array{Int,0}
+
+end


### PR DESCRIPTION
This should fix #37, by removing a `let` block left in for Julia 0.6. 

I bumped the version number to 0.5.0 in Project.toml, but to actually tag this version, someone needs to [install registrator](https://github.com/JuliaRegistries/Registrator.jl#install-registrator) plus ideally [tagbot](https://github.com/JuliaRegistries/TagBot), and then say this in a comment:

@JuliaRegistrator register()

I'm not precisely sure who has permissions to do this. 

While I was editing, I also removed the comment about scope from the readme, updated the links there to docs & other packages, and added `@testset`s to the tests. 

Edit: Tests on 0.7 failed, and locally trying it on 0.7 gives lots of warnings. So I dropped that too now. Anyone using 0.6 or 0.7 should still (after this is tagged) get the old version. 